### PR TITLE
Change MAX weapons to "max" sanction

### DIFF
--- a/Weapons/community-review/sanction-list.csv
+++ b/Weapons/community-review/sanction-list.csv
@@ -1,46 +1,46 @@
 ﻿Item ID,Item Category,Item Name,Sanction
-15016,AA MAX (Left),NS-10 Burster,none
-16016,AA MAX (Left),NS-10 Burster,none
-17016,AA MAX (Left),NS-10 Burster,none
-804742,AA MAX (Left),NS-10B Burster,
-804744,AA MAX (Left),NS-10B Burster,
-804746,AA MAX (Left),NS-10B Burster,
-804748,AA MAX (Left),NS-10G Burster,
-804750,AA MAX (Left),NS-10G Burster,
-804752,AA MAX (Left),NS-10G Burster,
-15004,AA MAX (Right),NS-10 Burster,none
-16004,AA MAX (Right),NS-10 Burster,none
-17004,AA MAX (Right),NS-10 Burster,none
-804741,AA MAX (Right),NS-10B Burster,
-804743,AA MAX (Right),NS-10B Burster,
-804745,AA MAX (Right),NS-10B Burster,
-804747,AA MAX (Right),NS-10G Burster,
-804749,AA MAX (Right),NS-10G Burster,
-804751,AA MAX (Right),NS-10G Burster,
-7507,AI MAX (Left),AF-23 Grinder,none
-7505,AI MAX (Left),AF-34 Mattock,none
-7506,AI MAX (Left),AF-41 Hacksaw,none
-7525,AI MAX (Left),Blueshift VM5,none
-7520,AI MAX (Left),Cosmos VM3,none
-15000,AI MAX (Left),M1 Heavy Cycler,none
-7513,AI MAX (Left),M2 Mutilator,none
-7512,AI MAX (Left),M6 Onslaught,none
-7518,AI MAX (Left),MRC3 Mercy,none
-16000,AI MAX (Left),NCM1 Scattercannon,none
-7519,AI MAX (Left),Nebula VM20,none
-17000,AI MAX (Left),Quasar VM1,none
-16026,AI MAX (Right),AF-23 Grinder,none
-16024,AI MAX (Right),AF-34 Mattock,none
-16025,AI MAX (Right),AF-41 Hacksaw,none
-17030,AI MAX (Right),Blueshift VM5,none
-17025,AI MAX (Right),Cosmos VM3,none
-15012,AI MAX (Right),M1 Heavy Cycler,none
-15025,AI MAX (Right),M2 Mutilator,none
-15024,AI MAX (Right),M6 Onslaught,none
-15030,AI MAX (Right),MRC3 Mercy,none
-16012,AI MAX (Right),NCM1 Scattercannon,none
-17024,AI MAX (Right),Nebula VM20,none
-17012,AI MAX (Right),Quasar VM1,none
+15016,AA MAX (Left),NS-10 Burster,max
+16016,AA MAX (Left),NS-10 Burster,max
+17016,AA MAX (Left),NS-10 Burster,max
+804742,AA MAX (Left),NS-10B Burster,max
+804744,AA MAX (Left),NS-10B Burster,max
+804746,AA MAX (Left),NS-10B Burster,max
+804748,AA MAX (Left),NS-10G Burster,max
+804750,AA MAX (Left),NS-10G Burster,max
+804752,AA MAX (Left),NS-10G Burster,max
+15004,AA MAX (Right),NS-10 Burster,max
+16004,AA MAX (Right),NS-10 Burster,max
+17004,AA MAX (Right),NS-10 Burster,max
+804741,AA MAX (Right),NS-10B Burster,max
+804743,AA MAX (Right),NS-10B Burster,max
+804745,AA MAX (Right),NS-10B Burster,max
+804747,AA MAX (Right),NS-10G Burster,max
+804749,AA MAX (Right),NS-10G Burster,max
+804751,AA MAX (Right),NS-10G Burster,max
+7507,AI MAX (Left),AF-23 Grinder,max
+7505,AI MAX (Left),AF-34 Mattock,max
+7506,AI MAX (Left),AF-41 Hacksaw,max
+7525,AI MAX (Left),Blueshift VM5,max
+7520,AI MAX (Left),Cosmos VM3,max
+15000,AI MAX (Left),M1 Heavy Cycler,max
+7513,AI MAX (Left),M2 Mutilator,max
+7512,AI MAX (Left),M6 Onslaught,max
+7518,AI MAX (Left),MRC3 Mercy,max
+16000,AI MAX (Left),NCM1 Scattercannon,max
+7519,AI MAX (Left),Nebula VM20,max
+17000,AI MAX (Left),Quasar VM1,max
+16026,AI MAX (Right),AF-23 Grinder,max
+16024,AI MAX (Right),AF-34 Mattock,max
+16025,AI MAX (Right),AF-41 Hacksaw,max
+17030,AI MAX (Right),Blueshift VM5,max
+17025,AI MAX (Right),Cosmos VM3,max
+15012,AI MAX (Right),M1 Heavy Cycler,max
+15025,AI MAX (Right),M2 Mutilator,max
+15024,AI MAX (Right),M6 Onslaught,max
+15030,AI MAX (Right),MRC3 Mercy,max
+16012,AI MAX (Right),NCM1 Scattercannon,max
+17024,AI MAX (Right),Nebula VM20,max
+17012,AI MAX (Right),Quasar VM1,max
 6004869,ANT Harvesting Tool,WLT-ARX Mining Laser,
 6004870,ANT Harvesting Tool,WLT-ARX Mining Laser,
 6004871,ANT Harvesting Tool,WLT-ARX Mining Laser,
@@ -88,42 +88,42 @@
 803498,ANT Top Turret,WLT-Yellowjacket Mining Laser,
 803499,ANT Top Turret,WLT-Yellowjacket Mining Laser,
 6005434,ANT Top Turret,WLT-Yellowjacket Mining Laser,
-17013,AV MAX (Left),Comet VM2,none
-15013,AV MAX (Left),M3 Pounder HEG,none
-16030,AV MAX (Left),MR1 Fracture,none
-16013,AV MAX (Left),NCM2 Falcon,none
-16028,AV MAX (Left),NCM3 Raven,none
-16032,AV MAX (Left),Vortex VM21,none
-6003600,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",
-6003601,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",
-6003603,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",
-804652,AV MAX (Left),NS-20 Gorgon,
-804654,AV MAX (Left),NS-20 Gorgon,
-804656,AV MAX (Left),NS-20 Gorgon,
-804717,AV MAX (Left),NS-20B Gorgon,
-804719,AV MAX (Left),NS-20B Gorgon,
-804721,AV MAX (Left),NS-20B Gorgon,
-804723,AV MAX (Left),NS-20G Gorgon,
-804725,AV MAX (Left),NS-20G Gorgon,
-804727,AV MAX (Left),NS-20G Gorgon,
-17001,AV MAX (Right),Comet VM2,none
-15001,AV MAX (Right),M3 Pounder HEG,none
-16031,AV MAX (Right),MR1 Fracture,none
-16001,AV MAX (Right),NCM2 Falcon,none
-16029,AV MAX (Right),NCM3 Raven,none
-16033,AV MAX (Right),Vortex VM21,none
-6003599,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",
-6003602,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",
-6003604,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",
-804653,AV MAX (Right),NS-20 Gorgon,
-804655,AV MAX (Right),NS-20 Gorgon,
-804657,AV MAX (Right),NS-20 Gorgon,
-804718,AV MAX (Right),NS-20B Gorgon,
-804720,AV MAX (Right),NS-20B Gorgon,
-804722,AV MAX (Right),NS-20B Gorgon,
-804724,AV MAX (Right),NS-20G Gorgon,
-804726,AV MAX (Right),NS-20G Gorgon,
-804728,AV MAX (Right),NS-20G Gorgon,
+17013,AV MAX (Left),Comet VM2,max
+15013,AV MAX (Left),M3 Pounder HEG,max
+16030,AV MAX (Left),MR1 Fracture,max
+16013,AV MAX (Left),NCM2 Falcon,max
+16028,AV MAX (Left),NCM3 Raven,max
+16032,AV MAX (Left),Vortex VM21,max
+6003600,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",max
+6003601,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",max
+6003603,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",max
+804652,AV MAX (Left),NS-20 Gorgon,max
+804654,AV MAX (Left),NS-20 Gorgon,max
+804656,AV MAX (Left),NS-20 Gorgon,max
+804717,AV MAX (Left),NS-20B Gorgon,max
+804719,AV MAX (Left),NS-20B Gorgon,max
+804721,AV MAX (Left),NS-20B Gorgon,max
+804723,AV MAX (Left),NS-20G Gorgon,max
+804725,AV MAX (Left),NS-20G Gorgon,max
+804727,AV MAX (Left),NS-20G Gorgon,max
+17001,AV MAX (Right),Comet VM2,max
+15001,AV MAX (Right),M3 Pounder HEG,max
+16031,AV MAX (Right),MR1 Fracture,max
+16001,AV MAX (Right),NCM2 Falcon,max
+16029,AV MAX (Right),NCM3 Raven,max
+16033,AV MAX (Right),Vortex VM21,max
+6003599,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",max
+6003602,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",max
+6003604,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",max
+804653,AV MAX (Right),NS-20 Gorgon,max
+804655,AV MAX (Right),NS-20 Gorgon,max
+804657,AV MAX (Right),NS-20 Gorgon,max
+804718,AV MAX (Right),NS-20B Gorgon,max
+804720,AV MAX (Right),NS-20B Gorgon,max
+804722,AV MAX (Right),NS-20B Gorgon,max
+804724,AV MAX (Right),NS-20G Gorgon,max
+804726,AV MAX (Right),NS-20G Gorgon,max
+804728,AV MAX (Right),NS-20G Gorgon,max
 802768,Aerial Combat Weapon,Rocklet Rifle,
 804939,Aerial Combat Weapon,Rocklet Rifle,
 804940,Aerial Combat Weapon,Rocklet Rifle,
@@ -888,9 +888,9 @@
 802584,Knife,Icikill,none
 286,Knife,Lumine Edge,none
 1,Knife,Mag-Cutter,none
-1082,Knife,MAX Punch,none
-1083,Knife,MAX Punch,none
-1084,Knife,MAX Punch,none
+1082,Knife,MAX Punch,max
+1083,Knife,MAX Punch,max
+1084,Knife,MAX Punch,max
 800627,Knife,NS AutoBlade,none
 802903,Knife,NS Campion,none
 802902,Knife,NS Harrower,none


### PR DESCRIPTION
This PR changes the sanction-list MAX weapons to be assigned to the "max" sanction for use with MAX specific statistics