### PR TITLE
Knives & max punch 'none', grenade printer 'max'

### DIFF
--- a/Weapons/community-review/sanction-list.csv
+++ b/Weapons/community-review/sanction-list.csv
@@ -479,7 +479,7 @@
 7540,Heavy Weapon,Lasher X2,none
 7528,Heavy Weapon,NC05 Jackhammer,none
 7533,Heavy Weapon,T7 Mini-Chaingun,none
-6008686,Heavy Weapon,Grenade Printer,
+6008686,Heavy Weapon,Grenade Printer,max
 803732,Heavy Weapon,Lasher X2 AE,
 6004144,Heavy Weapon,Lasher X2-P,
 803756,Heavy Weapon,NC05 Jackhammer AE,
@@ -888,36 +888,36 @@
 802584,Knife,Icikill,none
 286,Knife,Lumine Edge,none
 1,Knife,Mag-Cutter,none
-1082,Knife,MAX Punch,max
-1083,Knife,MAX Punch,max
-1084,Knife,MAX Punch,max
+1082,Knife,MAX Punch,none
+1083,Knife,MAX Punch,none
+1084,Knife,MAX Punch,none
 800627,Knife,NS AutoBlade,none
 802903,Knife,NS Campion,none
 802902,Knife,NS Harrower,none
 285,Knife,Ripper,none
 801969,Knife,The Slasher,none
-6008651,Knife,Ancient Psykinetic Blade,
-6005453,Knife,Carver AE,
-6008687,Knife,Defector Claws,
-6006080,Knife,Fatestealer,
-6005451,Knife,Lumine Edge AE,
-6006081,Knife,Nightshade,
-6006146,Knife,NS Campion,
-6006147,Knife,NS Campion,
-6004825,Knife,NS Commando,
-6009600,Knife,NS Firebug,
-6009463,Knife,NS Icebreaker,
-6009515,Knife,NS Icebreaker,
-6009516,Knife,NS Icebreaker,
-6009517,Knife,NS Icebreaker,
-6009518,Knife,NS Icebreaker,
-802904,Knife,NS Victory,
-6006067,Knife,NS-A Commando,
-6005664,Knife,NS-G Commando,
-804113,Knife,"NS-TMC-01 ""His Regards""",
-6005743,Knife,NS-W Survivor,
-804795,Knife,NSX Amaterasu,
-6005452,Knife,Ripper AE,
+6008651,Knife,Ancient Psykinetic Blade,none
+6005453,Knife,Carver AE,none
+6008687,Knife,Defector Claws,none
+6006080,Knife,Fatestealer,none
+6005451,Knife,Lumine Edge AE,none
+6006081,Knife,Nightshade,none
+6006146,Knife,NS Campion,none
+6006147,Knife,NS Campion,none
+6004825,Knife,NS Commando,none
+6009600,Knife,NS Firebug,none
+6009463,Knife,NS Icebreaker,none
+6009515,Knife,NS Icebreaker,none
+6009516,Knife,NS Icebreaker,none
+6009517,Knife,NS Icebreaker,none
+6009518,Knife,NS Icebreaker,none
+802904,Knife,NS Victory,none
+6006067,Knife,NS-A Commando,none
+6005664,Knife,NS-G Commando,none
+804113,Knife,"NS-TMC-01 ""His Regards""",none
+6005743,Knife,NS-W Survivor,none
+804795,Knife,NSX Amaterasu,none
+6005452,Knife,Ripper AE,none
 1894,LMG,Betelgeuse 54-A,infantry
 7232,LMG,EM1,infantry
 7235,LMG,EM6,infantry

--- a/Weapons/community-review/sanction-list.csv
+++ b/Weapons/community-review/sanction-list.csv
@@ -2,21 +2,21 @@
 15016,AA MAX (Left),NS-10 Burster,none
 16016,AA MAX (Left),NS-10 Burster,none
 17016,AA MAX (Left),NS-10 Burster,none
-804742,AA MAX (Left),NS-10B Burster,
-804744,AA MAX (Left),NS-10B Burster,
-804746,AA MAX (Left),NS-10B Burster,
-804748,AA MAX (Left),NS-10G Burster,
-804750,AA MAX (Left),NS-10G Burster,
-804752,AA MAX (Left),NS-10G Burster,
+804742,AA MAX (Left),NS-10B Burster,none
+804744,AA MAX (Left),NS-10B Burster,none
+804746,AA MAX (Left),NS-10B Burster,none
+804748,AA MAX (Left),NS-10G Burster,none
+804750,AA MAX (Left),NS-10G Burster,none
+804752,AA MAX (Left),NS-10G Burster,none
 15004,AA MAX (Right),NS-10 Burster,none
 16004,AA MAX (Right),NS-10 Burster,none
 17004,AA MAX (Right),NS-10 Burster,none
-804741,AA MAX (Right),NS-10B Burster,
-804743,AA MAX (Right),NS-10B Burster,
-804745,AA MAX (Right),NS-10B Burster,
-804747,AA MAX (Right),NS-10G Burster,
-804749,AA MAX (Right),NS-10G Burster,
-804751,AA MAX (Right),NS-10G Burster,
+804741,AA MAX (Right),NS-10B Burster,none
+804743,AA MAX (Right),NS-10B Burster,none
+804745,AA MAX (Right),NS-10B Burster,none
+804747,AA MAX (Right),NS-10G Burster,none
+804749,AA MAX (Right),NS-10G Burster,none
+804751,AA MAX (Right),NS-10G Burster,none
 7507,AI MAX (Left),AF-23 Grinder,none
 7505,AI MAX (Left),AF-34 Mattock,none
 7506,AI MAX (Left),AF-41 Hacksaw,none
@@ -94,36 +94,36 @@
 16013,AV MAX (Left),NCM2 Falcon,none
 16028,AV MAX (Left),NCM3 Raven,none
 16032,AV MAX (Left),Vortex VM21,none
-6003600,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",
-6003601,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",
-6003603,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",
-804652,AV MAX (Left),NS-20 Gorgon,
-804654,AV MAX (Left),NS-20 Gorgon,
-804656,AV MAX (Left),NS-20 Gorgon,
-804717,AV MAX (Left),NS-20B Gorgon,
-804719,AV MAX (Left),NS-20B Gorgon,
-804721,AV MAX (Left),NS-20B Gorgon,
-804723,AV MAX (Left),NS-20G Gorgon,
-804725,AV MAX (Left),NS-20G Gorgon,
-804727,AV MAX (Left),NS-20G Gorgon,
+6003600,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",none
+6003601,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",none
+6003603,AV MAX (Left),"NS-20 ""Heatwave"" Gorgon",none
+804652,AV MAX (Left),NS-20 Gorgon,none
+804654,AV MAX (Left),NS-20 Gorgon,none
+804656,AV MAX (Left),NS-20 Gorgon,none
+804717,AV MAX (Left),NS-20B Gorgon,none
+804719,AV MAX (Left),NS-20B Gorgon,none
+804721,AV MAX (Left),NS-20B Gorgon,none
+804723,AV MAX (Left),NS-20G Gorgon,none
+804725,AV MAX (Left),NS-20G Gorgon,none
+804727,AV MAX (Left),NS-20G Gorgon,none
 17001,AV MAX (Right),Comet VM2,none
 15001,AV MAX (Right),M3 Pounder HEG,none
 16031,AV MAX (Right),MR1 Fracture,none
 16001,AV MAX (Right),NCM2 Falcon,none
 16029,AV MAX (Right),NCM3 Raven,none
 16033,AV MAX (Right),Vortex VM21,none
-6003599,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",
-6003602,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",
-6003604,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",
-804653,AV MAX (Right),NS-20 Gorgon,
-804655,AV MAX (Right),NS-20 Gorgon,
-804657,AV MAX (Right),NS-20 Gorgon,
-804718,AV MAX (Right),NS-20B Gorgon,
-804720,AV MAX (Right),NS-20B Gorgon,
-804722,AV MAX (Right),NS-20B Gorgon,
-804724,AV MAX (Right),NS-20G Gorgon,
-804726,AV MAX (Right),NS-20G Gorgon,
-804728,AV MAX (Right),NS-20G Gorgon,
+6003599,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",none
+6003602,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",none
+6003604,AV MAX (Right),"NS-20 ""Heatwave"" Gorgon",none
+804653,AV MAX (Right),NS-20 Gorgon,none
+804655,AV MAX (Right),NS-20 Gorgon,none
+804657,AV MAX (Right),NS-20 Gorgon,none
+804718,AV MAX (Right),NS-20B Gorgon,none
+804720,AV MAX (Right),NS-20B Gorgon,none
+804722,AV MAX (Right),NS-20B Gorgon,none
+804724,AV MAX (Right),NS-20G Gorgon,none
+804726,AV MAX (Right),NS-20G Gorgon,none
+804728,AV MAX (Right),NS-20G Gorgon,none
 802768,Aerial Combat Weapon,Rocklet Rifle,
 804939,Aerial Combat Weapon,Rocklet Rifle,
 804940,Aerial Combat Weapon,Rocklet Rifle,


### PR DESCRIPTION
Change all unassigned knives to 'none' to match the others.
#19 changed max punch to 'max' but as a knife it should probably be 'none'
Also changed the Defector's grenade printer to 'max'