### PR TITLE
Update list script

### DIFF
--- a/Weapons/community-review/list.js
+++ b/Weapons/community-review/list.js
@@ -18,8 +18,8 @@ const { headers, rows } = await new Promise( resolve =>
 			.on( 'end', () => resolve( { headers, rows } ) );
 	} );
 
-//resort sanction-list
-if( process.argv[2] === 'resort' )
+//sort sanction-list
+if( process.argv[2] === 'sort' || process.argv[2] === 'sort-compile' )
 {
 	rows.sort( ( a, b ) =>
 		{
@@ -40,12 +40,22 @@ if( process.argv[2] === 'resort' )
 		} );
 }
 
-//compile into machine list
-else if( process.argv[2] === 'compile' )
+//compile into machine lists
+if( process.argv[2] === 'compile' || process.argv[2] === 'sort-compile' )
 {
 	csv.writeToPath( 'sanction-list-machine.csv',
 		rows
 			.filter( r => r.Sanction !== 'none' && r.Sanction !== '' )
+			.map( r => { delete r['Item Category']; delete r['Item Name']; return r; } )
+			.sort( ( a, b ) => parseInt( a['Item ID'] ) - parseInt( b['Item ID'] ) ),
+		{
+			encoding: 'utf8',
+			writeBOM: true,
+			writeHeaders: false
+		} );
+	csv.writeToPath( 'sanction-list-machine-with-none.csv',
+		rows
+			.filter( r => r.Sanction !== '' )
 			.map( r => { delete r['Item Category']; delete r['Item Name']; return r; } )
 			.sort( ( a, b ) => parseInt( a['Item ID'] ) - parseInt( b['Item ID'] ) ),
 		{

--- a/Weapons/community-review/list.js
+++ b/Weapons/community-review/list.js
@@ -43,21 +43,20 @@ if( process.argv[2] === 'sort' || process.argv[2] === 'sort-compile' )
 //compile into machine lists
 if( process.argv[2] === 'compile' || process.argv[2] === 'sort-compile' )
 {
-	csv.writeToPath( 'sanction-list-machine.csv',
-		rows
-			.filter( r => r.Sanction !== 'none' && r.Sanction !== '' )
-			.map( r => { delete r['Item Category']; delete r['Item Name']; return r; } )
-			.sort( ( a, b ) => parseInt( a['Item ID'] ) - parseInt( b['Item ID'] ) ),
+	//map rows into machine based rows
+	//(have to copy into new objects so race condition doesn't change regular rows before they are written)
+	const rows_machine = rows
+		.filter( r => r.Sanction !== '' )
+		.map( r => { return { ['Item ID']: r['Item ID'], Sanction: r.Sanction }; } )
+		.sort( ( a, b ) => parseInt( a['Item ID'] ) - parseInt( b['Item ID'] ) );
+
+	csv.writeToPath( 'sanction-list-machine.csv', rows_machine.filter( r => r.Sanction !== 'none' ),
 		{
 			encoding: 'utf8',
 			writeBOM: true,
 			writeHeaders: false
 		} );
-	csv.writeToPath( 'sanction-list-machine-with-none.csv',
-		rows
-			.filter( r => r.Sanction !== '' )
-			.map( r => { delete r['Item Category']; delete r['Item Name']; return r; } )
-			.sort( ( a, b ) => parseInt( a['Item ID'] ) - parseInt( b['Item ID'] ) ),
+	csv.writeToPath( 'sanction-list-machine-with-none.csv', rows_machine,
 		{
 			encoding: 'utf8',
 			writeBOM: true,

--- a/Weapons/community-review/package.json
+++ b/Weapons/community-review/package.json
@@ -2,8 +2,9 @@
   "name": "sanction-list",
   "type": "module",
   "scripts": {
+    "sort": "node list.js sort",
     "compile": "node list.js compile",
-      "resort": "node list.js resort"
+    "sort-compile": "node list sort-compile"
   },
   "dependencies": {
     "fast-csv": "^4.3.6"

--- a/Weapons/community-review/readme.md
+++ b/Weapons/community-review/readme.md
@@ -7,5 +7,6 @@ I hope that we as a community can use this list to come together on some updates
 Please make pull requests on this list and we can merge the final results back into a more optimized list later.
 
 There's a script to resort the human list and compile it into the machine list:
-* npm run resort
-* npm run compile
+* `npm run sort` (will sort the human readable list)
+* `npm run compile` (will compile the machine readable lists from the human readable list)
+* `npm run sort-compile` (will run both above commands)


### PR DESCRIPTION
* Changed `resort` command to just `sort`
* Added `sort-compile` command to perform both actions
* Updated readme on what each command does
* `compile` command will now also create a machine list including 'none'

Signed-off-by: Fred Kilbourn <fred@fredk.com>