### PR TITLE
Give libraries their own section and add more

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A collection of sites, applications and repositories that use the planetside 2 A
 - Golang [Censusgo](https://github.com/Lampjaw/censusgo)
 - JS [Dbgcensus](https://github.com/Lampjaw/dbgcensus)
 - TS [PS2Census](https://github.com/microwavekonijn/ps2census)
+- Elixir [Planetside API](https://github.com/Bentheburrito/planetside_api)
 
 ## Community API services repositories
 - [Tide OP Tracker](https://github.com/Varunda/topt)

--- a/README.md
+++ b/README.md
@@ -35,10 +35,15 @@ A collection of sites, applications and repositories that use the planetside 2 A
  - [PS2 Query Editor](https://eating-coleslaw.github.io/ps2-visual-query/)
  - [BinaryCoder](http://stats.binarycoder.info/)
 
- Planetside 2 Repositories
+## Census libraries
+- Python [Auraxium](https://github.com/leonhard-s/auraxium)
+- C# [DbgCensus](https://github.com/carlst99/DbgCensus)
+- C# [DaybreakGames.Census](https://github.com/Lampjaw/DaybreakGames.Census)
+- Golang [Censusgo](https://github.com/Lampjaw/censusgo)
+- JS [Dbgcensus](https://github.com/Lampjaw/dbgcensus)
+- TS [PS2Census](https://github.com/microwavekonijn/ps2census)
 
-- [Auraxium](https://github.com/leonhard-s/auraxium)
-- [DbgCensus](https://github.com/carlst99/DbgCensus)
+## Community API services repositories
 - [Tide OP Tracker](https://github.com/Varunda/topt)
 - [PS2Alerts](https://github.com/ps2alerts)
 - [PS2-Alerts.io](https://github.com/ps2-alerts/ps2-alerts.github.io)


### PR DESCRIPTION
Over the years quite some census libraries have popped up for multiple languages. Some already were added to the readme but I felt like the others should be added too. This made the previous section a bit to big so for readability I added a new library only section to the readme. I probably missed some, so feel free to add others.

I haven't asked any of the library owners for permission. I'm not sure if that's required, but I can go ask if necessary.