### PR TITLE
Add Auraxis-rs to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A collection of sites, applications and repositories that use the planetside 2 A
 - JS [Dbgcensus](https://github.com/Lampjaw/dbgcensus)
 - TS [PS2Census](https://github.com/microwavekonijn/ps2census)
 - Elixir [Planetside API](https://github.com/Bentheburrito/planetside_api)
+- Rust [Auraxis-rs](https://github.com/AnotherGenZ/auraxis-rs)
 
 ## Community API services repositories
 - [Nanite-Systems Stream Replacement](https://github.com/nanite-systems)


### PR DESCRIPTION
This PR adds Auraxis-rs, a Rust Census library to the readme. At this point the only documentation is a couple of examples and the auto generated Rust API docs, not sure if it should be added already?

Might look into contributing a readme and automatically generating the docs with a GitHub action and publishing them. The base Rust tooling already has the tools to generate these docs locally however.

Any thoughts?